### PR TITLE
add option to set file permissions open

### DIFF
--- a/dataset_loaders/config.ini.example
+++ b/dataset_loaders/config.ini.example
@@ -1,5 +1,6 @@
 [general]
 datasets_local_path = /the/local/path/where/the/datasets/will/be/copied
+open_permissions = False
 
 [camvid]
 shared_path = /data/lisatmp4/camvid/segnet/

--- a/dataset_loaders/parallel_loader.py
+++ b/dataset_loaders/parallel_loader.py
@@ -281,6 +281,14 @@ class ThreadedDataset(object):
             print('The local path {} does not exist. Copying '
                   'the dataset...'.format(self.path))
             shutil.copytree(self.shared_path, self.path)
+            
+            ## to make folder shared for others on same filesystem
+            if self.is_open_permissions == "True":
+                print "Setting permissions to 0755"
+                os.chmod(self.datasets_local_path, 0775)
+                for r,d,f in os.walk(self.path):
+                    os.chmod(r,0775)
+            
             with open(os.path.join(self.path, '__version__'), 'w') as f:
                 f.write(self.__version__)
             print('Done.')
@@ -302,6 +310,14 @@ class ThreadedDataset(object):
                 if realpath(self.path) != realpath(self.shared_path):
                     shutil.rmtree(self.path)
                     shutil.copytree(self.shared_path, self.path)
+                    
+                    ## to make folder shared for others on same filesystem
+                    if self.is_open_permissions == "True":
+                        print "Setting permissions to 0755"
+                        os.chmod(self.datasets_local_path, 0775)
+                        for r,d,f in os.walk(self.path):
+                            os.chmod(r,0775)
+                    
                 with open(os.path.join(self.path, '__version__'), 'w') as f:
                     f.write(self.__version__)
                 print('Done.')
@@ -808,7 +824,17 @@ class ThreadedDataset(object):
                                'path.' % config_path)
         config_parser.read(config_path)
         return config_parser
-
+    
+    @classproperty
+    def datasets_local_path(self):
+        config_parser = self.__config_parser__
+        return config_parser.get('general', 'datasets_local_path')
+    
+    @classproperty
+    def is_open_permissions(self):
+        config_parser = self.__config_parser__
+        return config_parser.get('general', 'open_permissions')
+    
     @classproperty
     def path(self):
         config_parser = self.__config_parser__


### PR DESCRIPTION
I extended Adriana's initial fix for shared file systems to be an option that is disabled by default so that it can be included in the main code and controlled with a parameter in config.ini. 

This will solve a headache when working on a project with more than one person and trying to not waste time and space copying datasets to each machine in a cluster.

As well as changing the permissions on the dataset it also changes them on the higher level folder. This solves the issue if the folder is created by another user (who has a umask to not share the folder)